### PR TITLE
Handle 400 bad request

### DIFF
--- a/gaggle/client.py
+++ b/gaggle/client.py
@@ -73,6 +73,8 @@ class Service:
                             logger.warning("Access denied even after refreshing token:")
                             logger.warning(await response.text())
                             raise AccessDenied("Access denied even after refreshing token")
+                    if response.status == 400:
+                        raise AccessDenied(f"Access denied: response.text()")
                     break
                 except asyncio.TimeoutError as e:
                     logger.warning("timeout: {}".format(e))


### PR DESCRIPTION
If a user has revoked access, google will return a 400 response code and

```
{
  "error": "invalid_grant",
  "error_description": "Token has been expired or revoked."
}
```